### PR TITLE
Add param for manifest file permissions

### DIFF
--- a/grok-manifest.py
+++ b/grok-manifest.py
@@ -18,6 +18,7 @@ import os
 import sys
 import logging
 import time
+import fnmatch
 
 import grokmirror
 
@@ -175,6 +176,9 @@ if __name__ == '__main__':
         action='store_true', default=False,
         help='When running with arguments, wait if manifest is not there '
              '(can be useful when multiple writers are writing the manifest)')
+    parser.add_option('-f', '--manifest-permissions', dest='manifest_permissions',
+        default='0644',
+        help='File permissions of the manifest.js or manifest.js.gz file in octal. Default is 0644')
     parser.add_option('-v', '--verbose', dest='verbose', action='store_true',
         default=False,
         help='Be verbose and tell us what you are doing')
@@ -187,6 +191,8 @@ if __name__ == '__main__':
         parser.error('You must provide the toplevel path')
     if not len(args) and opts.wait:
         parser.error('--wait option only makes sense when dirs are passed')
+    if not fnmatch.fnmatch(opts.manifest_permissions,'0[0-7][0-7][0-7]'):
+        parser.error('Manifest permissions must be a 4 digit octal number')
 
     logger.setLevel(logging.DEBUG)
 
@@ -233,7 +239,7 @@ if __name__ == '__main__':
         #      by removing a repository used as a reference for others
         #      also make sure we clean up any dangling symlinks
 
-        grokmirror.write_manifest(opts.manifile, manifest, pretty=opts.pretty)
+        grokmirror.write_manifest(opts.manifile, manifest, opts.manifest_permissions, pretty=opts.pretty)
         grokmirror.manifest_unlock(opts.manifile)
         sys.exit(0)
 
@@ -273,6 +279,6 @@ if __name__ == '__main__':
     if len(symlinks):
         set_symlinks(manifest, opts.toplevel, symlinks)
 
-    grokmirror.write_manifest(opts.manifile, manifest, pretty=opts.pretty)
+    grokmirror.write_manifest(opts.manifile, manifest, opts.manifest_permissions, pretty=opts.pretty)
     grokmirror.manifest_unlock(opts.manifile)
 

--- a/grokmirror/__init__.py
+++ b/grokmirror/__init__.py
@@ -238,7 +238,7 @@ def read_manifest(manifile, wait=False):
 
     return manifest
 
-def write_manifest(manifile, manifest, mtime=None, pretty=False):
+def write_manifest(manifile, manifest, manifest_permissions, mtime=None, pretty=False):
     import tempfile
     import shutil
     import gzip
@@ -266,7 +266,7 @@ def write_manifest(manifile, manifest, mtime=None, pretty=False):
 
         os.fsync(fd)
         fh.close()
-        os.chmod(tmpfile, 0644)
+        os.chmod(tmpfile, int(manifest_permissions,8))
         if mtime is not None:
             logger.debug('Setting mtime to %s' % mtime)
             os.utime(tmpfile, (mtime, mtime))


### PR DESCRIPTION
If pushes to git server use ssh, the post-receive git hook that executes grok-manifest will run as the user doing the push. Since the permissions default to 644, that user may not be able to write the manifest.js.gz file. 

The patch was tested using the following script. If there is a better way to do the tests, please let me know.
# !/bin/bash

set -x

grok_manifest=$HOME/repos/grokmirror/grok-manifest.py
top=$PWD
rm -rf test
mkdir test
cd test
git init repo1
cd repo1
touch a
git add a
git commit -m "Commit #1"
cd ..
mkdir git
cd git
git clone --bare ../repo1 bare1

cd $top

$grok_manifest -m $top/manifest.js.gz -t $top/git --use-now -v $top/test/git/bare1/
ls -al $top/manifest.js.gz

$grok_manifest -m $top/manifest.js.gz --manifest-permissions=0664 -t $top/git --use-now -v $top/test/git/bare1/
ls -al $top/manifest.js.gz

$grok_manifest -m $top/manifest.js.gz --manifest-permissions=0666 -t $top/git --use-now -v $top/test/git/bare1/
ls -al $top/manifest.js.gz

$grok_manifest -m $top/manifest.js.gz --manifest-permissions=0669 -t $top/git --use-now -v $top/test/git/bare1/
