### PR TITLE
Avoid interpolation when logging

### DIFF
--- a/grokmirror/__init__.py
+++ b/grokmirror/__init__.py
@@ -131,7 +131,7 @@ def get_repo_fingerprint(toplevel, gitdir, force=False):
         try:
             repo = Repo(fullpath)
         except:
-            logger.critical('Could not open %s. Bad repo?' % gitdir)
+            logger.critical('Could not open %s. Bad repo?', gitdir)
             return None
 
         if not len(repo.heads):
@@ -146,7 +146,7 @@ def get_repo_fingerprint(toplevel, gitdir, force=False):
             # of git-show-ref
             fingerprint = hashlib.sha1(refs + b"\n").hexdigest()
         except:
-            logger.critical('Could not fingerprint %s. Bad repo?' % gitdir)
+            logger.critical('Could not fingerprint %s. Bad repo?', gitdir)
             return None
 
         # Save it for future use
@@ -275,7 +275,7 @@ def read_manifest(manifile, wait=False):
         manifest = anyjson.deserialize(jdata)
     except:
         # We'll regenerate the file entirely on failure to parse
-        logger.critical('Unable to parse %s, will regenerate' % manifile)
+        logger.critical('Unable to parse %s, will regenerate', manifile)
         manifest = {}
 
     logger.debug('Manifest contains %s entries', len(manifest.keys()))

--- a/grokmirror/__init__.py
+++ b/grokmirror/__init__.py
@@ -97,7 +97,7 @@ def get_repo_timestamp(toplevel, gitdir):
             ts = int(contents)
             logger.debug('Timestamp for %s: %s', gitdir, ts)
         except ValueError:
-            logger.warning('Was not able to parse timestamp in %s' % tsfile)
+            logger.warning('Was not able to parse timestamp in %s', tsfile)
     else:
         logger.debug('No existing timestamp for %s', gitdir)
 

--- a/grokmirror/__init__.py
+++ b/grokmirror/__init__.py
@@ -47,7 +47,7 @@ def _lockname(fullpath):
 def lock_repo(fullpath, nonblocking=False):
     repolock = _lockname(fullpath)
 
-    logger.debug('Attempting to exclusive-lock %s' % repolock)
+    logger.debug('Attempting to exclusive-lock %s', repolock)
     lockfh = open(repolock, 'w')
 
     if nonblocking:
@@ -63,7 +63,7 @@ def lock_repo(fullpath, nonblocking=False):
 def unlock_repo(fullpath):
     global REPO_LOCKH
     if fullpath in REPO_LOCKH.keys():
-        logger.debug('Unlocking %s' % fullpath)
+        logger.debug('Unlocking %s', fullpath)
         lockf(REPO_LOCKH[fullpath], LOCK_UN)
         REPO_LOCKH[fullpath].close()
         del REPO_LOCKH[fullpath]
@@ -75,13 +75,13 @@ def is_bare_git_repo(path):
     sufficiently resembles a base git repo (good enough to fool git
     itself).
     """
-    logger.debug('Checking if %s is a git repository' % path)
+    logger.debug('Checking if %s is a git repository', path)
     if (os.path.isdir(os.path.join(path, 'objects')) and
             os.path.isdir(os.path.join(path, 'refs')) and
             os.path.isfile(os.path.join(path, 'HEAD'))):
         return True
 
-    logger.debug('Skipping %s: not a git repository' % path)
+    logger.debug('Skipping %s: not a git repository', path)
     return False
 
 
@@ -95,11 +95,11 @@ def get_repo_timestamp(toplevel, gitdir):
             contents = tsfh.read()
         try:
             ts = int(contents)
-            logger.debug('Timestamp for %s: %s' % (gitdir, ts))
+            logger.debug('Timestamp for %s: %s', gitdir, ts)
         except ValueError:
             logger.warning('Was not able to parse timestamp in %s' % tsfile)
     else:
-        logger.debug('No existing timestamp for %s' % gitdir)
+        logger.debug('No existing timestamp for %s', gitdir)
 
     return ts
 
@@ -111,22 +111,22 @@ def set_repo_timestamp(toplevel, gitdir, ts):
     with open(tsfile, 'wt') as tsfh:
         tsfh.write('%d' % ts)
 
-    logger.debug('Recorded timestamp for %s: %s' % (gitdir, ts))
+    logger.debug('Recorded timestamp for %s: %s', gitdir, ts)
 
 
 def get_repo_fingerprint(toplevel, gitdir, force=False):
     fullpath = os.path.join(toplevel, gitdir.lstrip('/'))
     if not os.path.exists(fullpath):
-        logger.debug('Cannot fingerprint %s, as it does not exist' % fullpath)
+        logger.debug('Cannot fingerprint %s, as it does not exist', fullpath)
         return None
 
     fpfile = os.path.join(fullpath, 'grokmirror.fingerprint')
     if not force and os.path.exists(fpfile):
         with open(fpfile, 'rt') as fpfh:
             fingerprint = fpfh.read()
-        logger.debug('Fingerprint for %s: %s' % (gitdir, fingerprint))
+        logger.debug('Fingerprint for %s: %s', gitdir, fingerprint)
     else:
-        logger.debug('Generating fingerprint for %s' % gitdir)
+        logger.debug('Generating fingerprint for %s', gitdir)
 
         try:
             repo = Repo(fullpath)
@@ -135,7 +135,7 @@ def get_repo_fingerprint(toplevel, gitdir, force=False):
             return None
 
         if not len(repo.heads):
-            logger.debug('No heads in %s, nothing to fingerprint.' % fullpath)
+            logger.debug('No heads in %s, nothing to fingerprint.', fullpath)
             return None
 
         try:
@@ -166,7 +166,7 @@ def set_repo_fingerprint(toplevel, gitdir, fingerprint=None):
     with open(fpfile, 'wt') as fpfh:
         fpfh.write('%s' % fingerprint)
 
-    logger.debug('Recorded fingerprint for %s: %s' % (gitdir, fingerprint))
+    logger.debug('Recorded fingerprint for %s: %s', gitdir, fingerprint)
     return fingerprint
 
 
@@ -177,7 +177,8 @@ def find_all_alt_repos(refrepo, manifest):
     :param manifest: full manifest of repositories we track
     :return: List of repositories using gitdir in its alternates
     """
-    logger.debug('Finding all repositories using %s as its alternates' % refrepo)
+    logger.debug('Finding all repositories using %s as its alternates',
+                 refrepo)
     refrepo = refrepo.lstrip('/')
     repolist = []
     for gitdir in manifest.keys():
@@ -194,7 +195,7 @@ def find_all_gitdirs(toplevel, ignore=None):
         ignore = []
 
     logger.info('Finding bare git repos in %s' % toplevel)
-    logger.debug('Ignore list: %s' % ' '.join(ignore))
+    logger.debug('Ignore list: %s', ' '.join(ignore))
     gitdirs = []
     for root, dirs, files in os.walk(toplevel, topdown=True):
         if not len(dirs):
@@ -210,7 +211,7 @@ def find_all_gitdirs(toplevel, ignore=None):
                     ignored = True
                     break
             if not ignored and is_bare_git_repo(os.path.join(root, name)):
-                logger.debug('Found %s' % os.path.join(root, name))
+                logger.debug('Found %s', os.path.join(root, name))
                 gitdirs.append(os.path.join(root, name))
                 torm.append(name)
 
@@ -224,11 +225,11 @@ def find_all_gitdirs(toplevel, ignore=None):
 def manifest_lock(manifile):
     global MANIFEST_LOCKH
     if MANIFEST_LOCKH is not None:
-        logger.debug('Manifest %s already locked' % manifile)
+        logger.debug('Manifest %s already locked', manifile)
 
     manilock = _lockname(manifile)
     MANIFEST_LOCKH = open(manilock, 'w')
-    logger.debug('Attempting to lock %s' % manilock)
+    logger.debug('Attempting to lock %s', manilock)
     lockf(MANIFEST_LOCKH, LOCK_EX)
     logger.debug('Manifest lock obtained')
 
@@ -236,7 +237,7 @@ def manifest_lock(manifile):
 def manifest_unlock(manifile):
     global MANIFEST_LOCKH
     if MANIFEST_LOCKH is not None:
-        logger.debug('Unlocking manifest %s' % manifile)
+        logger.debug('Unlocking manifest %s', manifile)
         lockf(MANIFEST_LOCKH, LOCK_UN)
         MANIFEST_LOCKH.close()
         MANIFEST_LOCKH = None
@@ -277,7 +278,7 @@ def read_manifest(manifile, wait=False):
         logger.critical('Unable to parse %s, will regenerate' % manifile)
         manifest = {}
 
-    logger.debug('Manifest contains %s entries' % len(manifest.keys()))
+    logger.debug('Manifest contains %s entries', len(manifest.keys()))
 
     return manifest
 
@@ -292,8 +293,8 @@ def write_manifest(manifile, manifest, mtime=None, pretty=False):
     (dirname, basename) = os.path.split(manifile)
     (fd, tmpfile) = tempfile.mkstemp(prefix=basename, dir=dirname)
     fh = os.fdopen(fd, 'wb', 0)
-    logger.debug('Created a temporary file in %s' % tmpfile)
-    logger.debug('Writing to %s' % tmpfile)
+    logger.debug('Created a temporary file in %s', tmpfile)
+    logger.debug('Writing to %s', tmpfile)
     try:
         if pretty:
             import json
@@ -316,13 +317,13 @@ def write_manifest(manifile, manifest, mtime=None, pretty=False):
         os.chmod(tmpfile, 0o0666 ^ curmask)
         os.umask(curmask)
         if mtime is not None:
-            logger.debug('Setting mtime to %s' % mtime)
+            logger.debug('Setting mtime to %s', mtime)
             os.utime(tmpfile, (mtime, mtime))
-        logger.debug('Moving %s to %s' % (tmpfile, manifile))
+        logger.debug('Moving %s to %s', tmpfile, manifile)
         shutil.move(tmpfile, manifile)
 
     finally:
         # If something failed, don't leave these trailing around
         if os.path.exists(tmpfile):
-            logger.debug('Removing %s' % tmpfile)
+            logger.debug('Removing %s', tmpfile)
             os.unlink(tmpfile)

--- a/grokmirror/__init__.py
+++ b/grokmirror/__init__.py
@@ -194,7 +194,7 @@ def find_all_gitdirs(toplevel, ignore=None):
     if ignore is None:
         ignore = []
 
-    logger.info('Finding bare git repos in %s' % toplevel)
+    logger.info('Finding bare git repos in %s', toplevel)
     logger.debug('Ignore list: %s', ' '.join(ignore))
     gitdirs = []
     for root, dirs, files in os.walk(toplevel, topdown=True):
@@ -258,7 +258,7 @@ def read_manifest(manifile, wait=False):
             manifest_lock(manifile)
 
     if not os.path.exists(manifile):
-        logger.info('%s not found, assuming initial run' % manifile)
+        logger.info('%s not found, assuming initial run', manifile)
         return {}
 
     if manifile.find('.gz') > 0:
@@ -267,7 +267,7 @@ def read_manifest(manifile, wait=False):
     else:
         fh = open(manifile, 'rb')
 
-    logger.info('Reading %s' % manifile)
+    logger.info('Reading %s', manifile)
     jdata = fh.read().decode('utf-8')
     fh.close()
 
@@ -288,7 +288,7 @@ def write_manifest(manifile, manifest, mtime=None, pretty=False):
     import shutil
     import gzip
 
-    logger.info('Writing new %s' % manifile)
+    logger.info('Writing new %s', manifile)
 
     (dirname, basename) = os.path.split(manifile)
     (fd, tmpfile) = tempfile.mkstemp(prefix=basename, dir=dirname)

--- a/grokmirror/dumb_pull.py
+++ b/grokmirror/dumb_pull.py
@@ -86,7 +86,7 @@ def dumb_pull_repo(gitdir, remotes, svn=False):
         repo = Repo(gitdir)
         assert repo.bare is True
     except:
-        logger.critical('Error opening %s.' % gitdir)
+        logger.critical('Error opening %s.', gitdir)
         logger.critical('Make sure it is a bare git repository.')
         sys.exit(1)
 
@@ -240,7 +240,7 @@ def dumb_pull(args, verbose=False, svn=False, remotes=None, posthook='',
     for entry in args:
         if entry[-4:] == '.git':
             if not os.path.exists(entry):
-                logger.critical('%s does not exist' % entry)
+                logger.critical('%s does not exist', entry)
                 continue
 
             logger.debug('Found %s', entry)

--- a/grokmirror/dumb_pull.py
+++ b/grokmirror/dumb_pull.py
@@ -48,7 +48,7 @@ def git_rev_parse_all(gitdir):
         if debug:
             logger.debug('Stderr: %s', '\n'.join(debug))
         if warn:
-            logger.warning('Stderr: %s' % '\n'.join(warn))
+            logger.warning('Stderr: %s', '\n'.join(warn))
 
     return output
 
@@ -76,7 +76,7 @@ def git_remote_update(args, env):
         if debug:
             logger.debug('Stderr: %s', '\n'.join(debug))
         if warn:
-            logger.warning('Stderr: %s' % '\n'.join(warn))
+            logger.warning('Stderr: %s', '\n'.join(warn))
 
 
 def dumb_pull_repo(gitdir, remotes, svn=False):
@@ -152,7 +152,7 @@ def run_post_update_hook(hookscript, gitdir):
     if hookscript == '':
         return
     if not os.access(hookscript, os.X_OK):
-        logger.warning('post_update_hook %s is not executable' % hookscript)
+        logger.warning('post_update_hook %s is not executable', hookscript)
         return
 
     args = [hookscript, gitdir]
@@ -165,7 +165,7 @@ def run_post_update_hook(hookscript, gitdir):
     output = output.strip()
     if error:
         # Put hook stderror into warning
-        logger.warning('Hook Stderr: %s' % error)
+        logger.warning('Hook Stderr: %s', error)
     if output:
         # Put hook stdout into info
         logger.info('Hook Stdout: %s', output)

--- a/grokmirror/dumb_pull.py
+++ b/grokmirror/dumb_pull.py
@@ -93,7 +93,7 @@ def dumb_pull_repo(gitdir, remotes, svn=False):
     try:
         grokmirror.lock_repo(gitdir, nonblocking=True)
     except IOError:
-        logger.info('Could not obtain exclusive lock on %s' % gitdir)
+        logger.info('Could not obtain exclusive lock on %s', gitdir)
         logger.info('\tAssuming another process is running.')
         return False
 
@@ -109,7 +109,7 @@ def dumb_pull_repo(gitdir, remotes, svn=False):
             if remote == '*':
                 remote = '--all'
 
-            logger.info('Running git-svn fetch %s in %s' % (remote, gitdir))
+            logger.info('Running git-svn fetch %s in %s', remote, gitdir)
             args = ['/usr/bin/git', 'svn', 'fetch', remote]
             git_remote_update(args, env)
 
@@ -117,7 +117,7 @@ def dumb_pull_repo(gitdir, remotes, svn=False):
         # Not an svn remote
         hasremotes = repo.git.remote()
         if not len(hasremotes.strip()):
-            logger.info('Repository %s has no defined remotes!' % gitdir)
+            logger.info('Repository %s has no defined remotes!', gitdir)
             return False
 
         logger.debug('existing remotes: %s', hasremotes)
@@ -129,14 +129,13 @@ def dumb_pull_repo(gitdir, remotes, svn=False):
                     logger.debug('existing remote %s matches %s',
                                  hasremote, remote)
                     args = ['/usr/bin/git', 'remote', 'update', hasremote]
-                    logger.info('Updating remote %s in %s' %
-                                (hasremote, gitdir))
+                    logger.info('Updating remote %s in %s', hasremote, gitdir)
 
                     git_remote_update(args, env)
 
             if not remotefound:
-                logger.info('Could not find any remotes matching %s in %s' % (
-                    remote, gitdir))
+                logger.info('Could not find any remotes matching %s in %s',
+                            remote, gitdir)
 
     new_revs = git_rev_parse_all(gitdir)
     grokmirror.unlock_repo(gitdir)
@@ -169,7 +168,7 @@ def run_post_update_hook(hookscript, gitdir):
         logger.warning('Hook Stderr: %s' % error)
     if output:
         # Put hook stdout into info
-        logger.info('Hook Stdout: %s' % output)
+        logger.info('Hook Stdout: %s', output)
 
 
 def parse_args():

--- a/grokmirror/dumb_pull.py
+++ b/grokmirror/dumb_pull.py
@@ -46,7 +46,7 @@ def git_rev_parse_all(gitdir):
         for line in error.split('\n'):
                 warn.append(line)
         if debug:
-            logger.debug('Stderr: %s' % '\n'.join(debug))
+            logger.debug('Stderr: %s', '\n'.join(debug))
         if warn:
             logger.warning('Stderr: %s' % '\n'.join(warn))
 
@@ -54,7 +54,7 @@ def git_rev_parse_all(gitdir):
 
 
 def git_remote_update(args, env):
-    logger.debug('Running: GIT_DIR=%s %s' % (env['GIT_DIR'], ' '.join(args)))
+    logger.debug('Running: GIT_DIR=%s %s', env['GIT_DIR'], ' '.join(args))
 
     (output, error) = subprocess.Popen(
         args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
@@ -74,14 +74,14 @@ def git_remote_update(args, env):
             else:
                 warn.append(line)
         if debug:
-            logger.debug('Stderr: %s' % '\n'.join(debug))
+            logger.debug('Stderr: %s', '\n'.join(debug))
         if warn:
             logger.warning('Stderr: %s' % '\n'.join(warn))
 
 
 def dumb_pull_repo(gitdir, remotes, svn=False):
     # verify it's a git repo and fetch all remotes
-    logger.debug('Will pull %s with following remotes: %s' % (gitdir, remotes))
+    logger.debug('Will pull %s with following remotes: %s', gitdir, remotes)
     try:
         repo = Repo(gitdir)
         assert repo.bare is True
@@ -102,7 +102,7 @@ def dumb_pull_repo(gitdir, remotes, svn=False):
     old_revs = git_rev_parse_all(gitdir)
 
     if svn:
-        logger.debug('Using git-svn for %s' % gitdir)
+        logger.debug('Using git-svn for %s', gitdir)
 
         for remote in remotes:
             # arghie-argh-argh
@@ -120,14 +120,14 @@ def dumb_pull_repo(gitdir, remotes, svn=False):
             logger.info('Repository %s has no defined remotes!' % gitdir)
             return False
 
-        logger.debug('existing remotes: %s' % hasremotes)
+        logger.debug('existing remotes: %s', hasremotes)
         for remote in remotes:
             remotefound = False
             for hasremote in hasremotes.split('\n'):
                 if fnmatch.fnmatch(hasremote, remote):
                     remotefound = True
-                    logger.debug('existing remote %s matches %s' % (
-                        hasremote, remote))
+                    logger.debug('existing remote %s matches %s',
+                                 hasremote, remote)
                     args = ['/usr/bin/git', 'remote', 'update', hasremote]
                     logger.info('Updating remote %s in %s' %
                                 (hasremote, gitdir))
@@ -157,7 +157,7 @@ def run_post_update_hook(hookscript, gitdir):
         return
 
     args = [hookscript, gitdir]
-    logger.debug('Running: %s' % ' '.join(args))
+    logger.debug('Running: %s', ' '.join(args))
     (output, error) = subprocess.Popen(args, stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE,
                                        universal_newlines=True).communicate()
@@ -244,13 +244,13 @@ def dumb_pull(args, verbose=False, svn=False, remotes=None, posthook='',
                 logger.critical('%s does not exist' % entry)
                 continue
 
-            logger.debug('Found %s' % entry)
+            logger.debug('Found %s', entry)
             didwork = dumb_pull_repo(entry, remotes, svn=svn)
             if didwork:
                 run_post_update_hook(posthook, entry)
 
         else:
-            logger.debug('Finding all git repos in %s' % entry)
+            logger.debug('Finding all git repos in %s', entry)
             for founddir in grokmirror.find_all_gitdirs(entry):
                 didwork = dumb_pull_repo(founddir, remotes, svn=svn)
                 if didwork:

--- a/grokmirror/fsck.py
+++ b/grokmirror/fsck.py
@@ -100,7 +100,7 @@ def run_git_repack(fullpath, config, full_repack=False):
 
     env = {'GIT_DIR': fullpath}
     args = ['/usr/bin/git', 'repack'] + flags
-    logger.info(' repack : repacking with %s' % repack_flags)
+    logger.info(' repack : repacking with %s', repack_flags)
 
     logger.debug('Running: GIT_DIR=%s %s', env['GIT_DIR'], ' '.join(args))
 
@@ -251,7 +251,7 @@ def fsck_mirror(name, config, verbose=False, force=False, conn_only=False, repac
     if conn_only or repack_all_quick or repack_all_full:
         force = True
 
-    logger.info('Running grok-fsck for [%s]' % name)
+    logger.info('Running grok-fsck for [%s]', name)
 
     # Lock the tree to make sure we only run one instance
     logger.debug('Attempting to obtain lock on %s', config['lock'])
@@ -259,14 +259,14 @@ def fsck_mirror(name, config, verbose=False, force=False, conn_only=False, repac
     try:
         lockf(flockh, LOCK_EX | LOCK_NB)
     except IOError:
-        logger.info('Could not obtain exclusive lock on %s' % config['lock'])
+        logger.info('Could not obtain exclusive lock on %s', config['lock'])
         logger.info('Assuming another process is running.')
         return 0
 
     manifest = grokmirror.read_manifest(config['manifest'])
 
     if os.path.exists(config['statusfile']):
-        logger.info('Reading status from %s' % config['statusfile'])
+        logger.info('Reading status from %s', config['statusfile'])
         stfh = open(config['statusfile'], 'rb')
         try:
             # Format of the status file:
@@ -309,8 +309,8 @@ def fsck_mirror(name, config, verbose=False, force=False, conn_only=False, repac
                 'lastcheck': 'never',
                 'nextcheck': nextcheck,
             }
-            logger.info('%s:' % fullpath)
-            logger.info('  added : next check on %s' % nextcheck)
+            logger.info('%s:', fullpath)
+            logger.info('  added : next check on %s', nextcheck)
 
     total_checked = 0
     total_elapsed = 0
@@ -319,7 +319,7 @@ def fsck_mirror(name, config, verbose=False, force=False, conn_only=False, repac
     # (unless --force, which is EVERYTHING)
     todayiso = today.strftime('%F')
     for fullpath in list(status):
-        logger.info('%s:' % fullpath)
+        logger.info('%s:', fullpath)
         # Check to make sure it's still in the manifest
         gitdir = fullpath.replace(config['toplevel'], '', 1)
         gitdir = '/' + gitdir.lstrip('/')
@@ -435,8 +435,8 @@ def fsck_mirror(name, config, verbose=False, force=False, conn_only=False, repac
     if not total_checked:
         logger.info('No new repos to check.')
     else:
-        logger.info('Repos checked: %s' % total_checked)
-        logger.info('Total running time: %s s' % int(total_elapsed))
+        logger.info('Repos checked: %s', total_checked)
+        logger.info('Total running time: %s s', int(total_elapsed))
         with open(config['statusfile'], 'wb') as stfh:
             stfh.write(json.dumps(status, indent=2).encode('utf-8'))
 

--- a/grokmirror/fsck.py
+++ b/grokmirror/fsck.py
@@ -405,7 +405,9 @@ def fsck_mirror(name, config, verbose=False, force=False, conn_only=False, repac
                 else:
                     logger.debug('Skipping fsck as requested.')
             else:
-                logger.warning('Repacking %s was unsuccessful, please run fsck manually!' % gitdir)
+                logger.warning('Repacking %s was unsuccessful, '
+                               'please run fsck manually!',
+                               gitdir)
 
             total_checked += 1
 

--- a/grokmirror/fsck.py
+++ b/grokmirror/fsck.py
@@ -48,7 +48,7 @@ def run_git_prune(fullpath, config, manifest):
     args = ['/usr/bin/git', 'prune']
     logger.info('  prune : pruning')
 
-    logger.debug('Running: GIT_DIR=%s %s' % (env['GIT_DIR'], ' '.join(args)))
+    logger.debug('Running: GIT_DIR=%s %s', env['GIT_DIR'], ' '.join(args))
 
     (output, error) = subprocess.Popen(
         args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
@@ -71,7 +71,7 @@ def run_git_prune(fullpath, config, manifest):
                 warn.append(line)
 
         if debug:
-            logger.debug('Stderr: %s' % '\n'.join(debug))
+            logger.debug('Stderr: %s', '\n'.join(debug))
         if warn:
             logger.critical('Pruning %s returned critical errors:' % fullpath)
             prune_ok = False
@@ -91,7 +91,7 @@ def run_git_repack(fullpath, config, full_repack=False):
 
     if full_repack and 'full_repack_flags' in config.keys():
         repack_flags = config['full_repack_flags']
-        logger.debug('Time to do a full repack of %s' % fullpath)
+        logger.debug('Time to do a full repack of %s', fullpath)
 
     elif 'repack_flags' in config.keys():
         repack_flags = config['repack_flags']
@@ -102,7 +102,7 @@ def run_git_repack(fullpath, config, full_repack=False):
     args = ['/usr/bin/git', 'repack'] + flags
     logger.info(' repack : repacking with %s' % repack_flags)
 
-    logger.debug('Running: GIT_DIR=%s %s' % (env['GIT_DIR'], ' '.join(args)))
+    logger.debug('Running: GIT_DIR=%s %s', env['GIT_DIR'], ' '.join(args))
 
     (output, error) = subprocess.Popen(
         args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
@@ -127,7 +127,7 @@ def run_git_repack(fullpath, config, full_repack=False):
                 warn.append(line)
 
         if debug:
-            logger.debug('Stderr: %s' % '\n'.join(debug))
+            logger.debug('Stderr: %s', '\n'.join(debug))
         if warn:
             logger.critical('Repacking %s returned critical errors:' % fullpath)
             repack_ok = False
@@ -142,7 +142,7 @@ def run_git_repack(fullpath, config, full_repack=False):
     args = ['/usr/bin/git', 'pack-refs', '--all']
     logger.info(' repack : repacking refs')
 
-    logger.debug('Running: GIT_DIR=%s %s' % (env['GIT_DIR'], ' '.join(args)))
+    logger.debug('Running: GIT_DIR=%s %s', env['GIT_DIR'], ' '.join(args))
 
     (output, error) = subprocess.Popen(
         args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
@@ -167,7 +167,7 @@ def run_git_repack(fullpath, config, full_repack=False):
                 warn.append(line)
 
         if debug:
-            logger.debug('Stderr: %s' % '\n'.join(debug))
+            logger.debug('Stderr: %s', '\n'.join(debug))
         if warn:
             logger.critical('Repacking refs %s returned critical errors:' % fullpath)
             repack_ok = False
@@ -185,7 +185,7 @@ def run_git_fsck(fullpath, config, conn_only=False):
     else:
         logger.info('   fsck : running full checks')
 
-    logger.debug('Running: GIT_DIR=%s %s' % (env['GIT_DIR'], ' '.join(args)))
+    logger.debug('Running: GIT_DIR=%s %s', env['GIT_DIR'], ' '.join(args))
 
     (output, error) = subprocess.Popen(
         args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
@@ -208,7 +208,7 @@ def run_git_fsck(fullpath, config, conn_only=False):
                 warn.append(line)
 
         if debug:
-            logger.debug('Stderr: %s' % '\n'.join(debug))
+            logger.debug('Stderr: %s', '\n'.join(debug))
         if warn:
             logger.critical('%s has critical errors:' % fullpath)
             for entry in warn:
@@ -254,7 +254,7 @@ def fsck_mirror(name, config, verbose=False, force=False, conn_only=False, repac
     logger.info('Running grok-fsck for [%s]' % name)
 
     # Lock the tree to make sure we only run one instance
-    logger.debug('Attempting to obtain lock on %s' % config['lock'])
+    logger.debug('Attempting to obtain lock on %s', config['lock'])
     flockh = open(config['lock'], 'w')
     try:
         lockf(flockh, LOCK_EX | LOCK_NB)
@@ -336,7 +336,7 @@ def fsck_mirror(name, config, verbose=False, force=False, conn_only=False, repac
                                                '%Y-%m-%d')
 
         if force or nextcheck <= today:
-            logger.debug('Preparing to check %s' % fullpath)
+            logger.debug('Preparing to check %s', fullpath)
             # Calculate elapsed seconds
             startt = time.time()
 
@@ -368,12 +368,14 @@ def fsck_mirror(name, config, verbose=False, force=False, conn_only=False, repac
                         # We -1 because if we want a repack every 10th time, then we need to trigger
                         # when current repack count is 9.
                         if quick_repack_count >= full_repack_every-1:
-                            logger.debug('Time to do full repack on %s' % fullpath)
+                            logger.debug('Time to do full repack on %s',
+                                         fullpath)
                             full_repack = True
                             quick_repack_count = 0
                             status[fullpath]['lastfullrepack'] = todayiso
                         else:
-                            logger.debug('Repack count for %s not yet reached full repack trigger' % fullpath)
+                            logger.debug('Repack count for %s not yet reached '
+                                         'full repack trigger', fullpath)
                             quick_repack_count += 1
 
                 # Don't run repack if we're running --connectivity without --repack-all-*
@@ -426,7 +428,7 @@ def fsck_mirror(name, config, verbose=False, force=False, conn_only=False, repac
 
             # Write status file after each check, so if the process dies, we won't
             # have to recheck all the repos we've already checked
-            logger.debug('Updating status file in %s' % config['statusfile'])
+            logger.debug('Updating status file in %s', config['statusfile'])
             with open(config['statusfile'], 'wb') as stfh:
                 stfh.write(json.dumps(status, indent=2).encode('utf-8'))
 

--- a/grokmirror/fsck.py
+++ b/grokmirror/fsck.py
@@ -73,10 +73,10 @@ def run_git_prune(fullpath, config, manifest):
         if debug:
             logger.debug('Stderr: %s', '\n'.join(debug))
         if warn:
-            logger.critical('Pruning %s returned critical errors:' % fullpath)
+            logger.critical('Pruning %s returned critical errors:', fullpath)
             prune_ok = False
             for entry in warn:
-                logger.critical("\t%s" % entry)
+                logger.critical("\t%s", entry)
 
     return prune_ok
 
@@ -129,10 +129,10 @@ def run_git_repack(fullpath, config, full_repack=False):
         if debug:
             logger.debug('Stderr: %s', '\n'.join(debug))
         if warn:
-            logger.critical('Repacking %s returned critical errors:' % fullpath)
+            logger.critical('Repacking %s returned critical errors:', fullpath)
             repack_ok = False
             for entry in warn:
-                logger.critical("\t%s" % entry)
+                logger.critical("\t%s", entry)
 
     if not repack_ok:
         # No need to repack refs if repo is broken
@@ -169,10 +169,11 @@ def run_git_repack(fullpath, config, full_repack=False):
         if debug:
             logger.debug('Stderr: %s', '\n'.join(debug))
         if warn:
-            logger.critical('Repacking refs %s returned critical errors:' % fullpath)
+            logger.critical('Repacking refs %s returned critical errors:',
+                            fullpath)
             repack_ok = False
             for entry in warn:
-                logger.critical("\t%s" % entry)
+                logger.critical("\t%s", entry)
 
     return repack_ok
 
@@ -210,9 +211,9 @@ def run_git_fsck(fullpath, config, conn_only=False):
         if debug:
             logger.debug('Stderr: %s', '\n'.join(debug))
         if warn:
-            logger.critical('%s has critical errors:' % fullpath)
+            logger.critical('%s has critical errors:', fullpath)
             for entry in warn:
-                logger.critical("\t%s" % entry)
+                logger.critical("\t%s", entry)
 
 
 def fsck_mirror(name, config, verbose=False, force=False, conn_only=False, repack_all_quick=False, repack_all_full=False):
@@ -285,7 +286,7 @@ def fsck_mirror(name, config, verbose=False, force=False, conn_only=False, repac
             status = json.loads(stfh.read().decode('utf-8'))
         except:
             # Huai le!
-            logger.critical('Failed to parse %s' % config['statusfile'])
+            logger.critical('Failed to parse %s', config['statusfile'])
             lockf(flockh, LOCK_UN)
             flockh.close()
             return 1

--- a/grokmirror/manifest.py
+++ b/grokmirror/manifest.py
@@ -35,7 +35,7 @@ def update_manifest(manifest, toplevel, gitdir, usenow):
         repo = Repo(gitdir)
         assert repo.bare is True
     except:
-        logger.critical('Error opening %s.' % gitdir)
+        logger.critical('Error opening %s.', gitdir)
         logger.critical('Make sure it is a bare git repository.')
         sys.exit(1)
 

--- a/grokmirror/manifest.py
+++ b/grokmirror/manifest.py
@@ -42,11 +42,11 @@ def update_manifest(manifest, toplevel, gitdir, usenow):
     # Ignore it if it's an empty git repository
     try:
         if len(repo.heads) == 0:
-            logger.info('%s has no heads, ignoring' % gitdir)
+            logger.info('%s has no heads, ignoring', gitdir)
             return
     except:
         # Errors when listing heads usually means repository is no good
-        logger.info('Error listing heads in %s, ignoring' % gitdir)
+        logger.info('Error listing heads in %s, ignoring', gitdir)
         return
 
     try:
@@ -86,10 +86,10 @@ def update_manifest(manifest, toplevel, gitdir, usenow):
             reference = alternate.replace(toplevel, '').replace('/objects', '')
 
     if path not in manifest.keys():
-        logger.info('Adding %s to manifest' % path)
+        logger.info('Adding %s to manifest', path)
         manifest[path] = {}
     else:
-        logger.info('Updating %s in the manifest' % path)
+        logger.info('Updating %s in the manifest', path)
 
     # we need a way to quickly compare whether mirrored repositories match
     # what is in the master manifest. To this end, we calculate a so-called
@@ -111,35 +111,35 @@ def set_symlinks(manifest, toplevel, symlinks):
     for symlink in symlinks:
         target = os.path.realpath(symlink)
         if target.find(toplevel) < 0:
-            logger.info('Symlink %s points outside toplevel, ignored' % symlink)
+            logger.info('Symlink %s points outside toplevel, ignored', symlink)
             continue
         tgtgitdir = target.replace(toplevel, '')
         if tgtgitdir not in manifest.keys():
-            logger.info('Symlink %s points to %s, which we do not recognize'
-                        % (symlink, target))
+            logger.info('Symlink %s points to %s, which we do not recognize',
+                        symlink, target)
             continue
         relative = symlink.replace(toplevel, '')
         if 'symlinks' in manifest[tgtgitdir].keys():
             if relative not in manifest[tgtgitdir]['symlinks']:
-                logger.info('Recording symlink %s->%s' % (relative, tgtgitdir))
+                logger.info('Recording symlink %s->%s', relative, tgtgitdir)
                 manifest[tgtgitdir]['symlinks'].append(relative)
         else:
             manifest[tgtgitdir]['symlinks'] = [relative]
-            logger.info('Recording symlink %s to %s' % (relative, tgtgitdir))
+            logger.info('Recording symlink %s to %s', relative, tgtgitdir)
 
         # Now go through all repos and fix any references pointing to the
         # symlinked location.
         for gitdir in manifest.keys():
             if manifest[gitdir]['reference'] == relative:
-                logger.info('Adjusted symlinked reference for %s: %s->%s'
-                            % (gitdir, relative, tgtgitdir))
+                logger.info('Adjusted symlinked reference for %s: %s->%s',
+                            gitdir, relative, tgtgitdir)
                 manifest[gitdir]['reference'] = tgtgitdir
 
 
 def purge_manifest(manifest, toplevel, gitdirs):
     for oldrepo in list(manifest):
         if os.path.join(toplevel, oldrepo.lstrip('/')) not in gitdirs:
-            logger.info('Purged deleted %s' % oldrepo)
+            logger.info('Purged deleted %s', oldrepo)
             del manifest[oldrepo]
 
 
@@ -247,9 +247,9 @@ def grok_manifest(manifile, toplevel, args=None, logfile=None, usenow=False,
             repo = fullpath.replace(toplevel, '', 1)
             if repo in manifest.keys():
                 del manifest[repo]
-                logger.info('Repository %s removed from manifest' % repo)
+                logger.info('Repository %s removed from manifest', repo)
             else:
-                logger.info('Repository %s not in manifest' % repo)
+                logger.info('Repository %s not in manifest', repo)
 
         # XXX: need to add logic to make sure we don't break the world
         #      by removing a repository used as a reference for others
@@ -281,7 +281,7 @@ def grok_manifest(manifile, toplevel, args=None, logfile=None, usenow=False,
             repo = gitdir.replace(toplevel, '', 1)
             if repo in list(manifest):
                 logger.info('Repository %s is no longer exported, '
-                            'removing from manifest' % repo)
+                            'removing from manifest', repo)
                 del manifest[repo]
 
             # XXX: need to add logic to make sure we don't break the world

--- a/grokmirror/manifest.py
+++ b/grokmirror/manifest.py
@@ -30,7 +30,7 @@ def update_manifest(manifest, toplevel, gitdir, usenow):
     path = gitdir.replace(toplevel, '', 1)
 
     # Try to open git dir
-    logger.debug('Examining %s' % gitdir)
+    logger.debug('Examining %s', gitdir)
     try:
         repo = Repo(gitdir)
         assert repo.bare is True

--- a/grokmirror/pull.py
+++ b/grokmirror/pull.py
@@ -120,7 +120,7 @@ class PullerThread(threading.Thread):
                     self.in_queue.task_done()
                     continue
 
-                logger.info('[Thread-%s] updating %s' % (self.myname, gitdir))
+                logger.info('[Thread-%s] updating %s', self.myname, gitdir)
                 success = pull_repo(self.toplevel, gitdir, threadid=self.myname)
                 logger.debug('[Thread-%s] done pulling %s',
                              self.myname, gitdir)
@@ -141,8 +141,8 @@ class PullerThread(threading.Thread):
                 grokmirror.unlock_repo(fullpath)
             except IOError:
                 my_fingerprint = fingerprint
-                logger.info('[Thread-%s] Could not lock %s, skipping'
-                            % (self.myname, gitdir))
+                logger.info('[Thread-%s] Could not lock %s, skipping',
+                            self.myname, gitdir)
                 lock_fails.append(gitdir)
 
             self.out_queue.put((gitdir, my_fingerprint, success))
@@ -225,7 +225,7 @@ def set_repo_params(toplevel, gitdir, owner, description, reference):
 
         objects = os.path.join(toplevel, reference.lstrip('/'), 'objects')
         altfile = os.path.join(fullpath, 'objects', 'info', 'alternates')
-        logger.info('Setting %s alternates to: %s' % (gitdir, objects))
+        logger.info('Setting %s alternates to: %s', gitdir, objects)
         with open(altfile, 'wt') as altfh:
             altfh.write('%s\n' % objects)
 
@@ -267,7 +267,7 @@ def run_post_update_hook(hookscript, toplevel, gitdir, threadid='X'):
         logger.warning('[Thread-%s] Hook Stderr: %s' % (threadid, error))
     if output:
         # Put hook stdout into info
-        logger.info('[Thread-%s] Hook Stdout: %s' % (threadid, output))
+        logger.info('[Thread-%s] Hook Stdout: %s', threadid, output)
 
 
 def pull_repo(toplevel, gitdir, threadid='X'):
@@ -321,9 +321,9 @@ def clone_repo(toplevel, gitdir, site, reference=None):
     args.append(source)
     args.append(dest)
 
-    logger.info('Cloning %s into %s' % (source, dest))
+    logger.info('Cloning %s into %s', source, dest)
     if reference is not None:
-        logger.info('With reference to %s' % reference)
+        logger.info('With reference to %s', reference)
 
     logger.debug('Running: %s', ' '.join(args))
 
@@ -407,7 +407,7 @@ def write_projects_list(manifest, config):
 
     (dirname, basename) = os.path.split(plpath)
     (fd, tmpfile) = tempfile.mkstemp(prefix=basename, dir=dirname)
-    logger.info('Writing new %s' % plpath)
+    logger.info('Writing new %s', plpath)
 
     try:
         with open(tmpfile, 'wt') as fh:
@@ -481,11 +481,11 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
     # push it into grokmirror to override the default logger
     grokmirror.logger = logger
 
-    logger.info('Checking [%s]' % name)
+    logger.info('Checking [%s]', name)
     mymanifest = config['mymanifest']
 
     if verify:
-        logger.info('Verifying mirror against %s' % config['manifest'])
+        logger.info('Verifying mirror against %s', config['manifest'])
         nomtime = True
 
     if config['manifest'].find('file:///') == 0:
@@ -507,7 +507,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
                 logger.info('Manifest file unchanged. Quitting.')
                 return 0
 
-        logger.info('Reading new manifest from %s' % manifile)
+        logger.info('Reading new manifest from %s', manifile)
         manifest = grokmirror.read_manifest(manifile)
         # Don't accept empty manifests -- that indicates something is wrong
         if not len(manifest.keys()):
@@ -516,7 +516,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
 
     else:
         # Load it from remote host using http and header magic
-        logger.info('Fetching remote manifest from %s' % config['manifest'])
+        logger.info('Fetching remote manifest from %s', config['manifest'])
 
         # Do we have username:password@ in the URL?
         chunks = urlparse(config['manifest'])
@@ -628,7 +628,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
         try:
             grokmirror.lock_repo(fullpath, nonblocking=True)
         except IOError:
-            logger.info('Could not lock %s, skipping' % gitdir)
+            logger.info('Could not lock %s, skipping', gitdir)
             lock_fails.append(gitdir)
             # Force the fingerprint to what we have in mymanifest,
             # if we have it.
@@ -637,8 +637,8 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
                 culled[gitdir]['fingerprint'] = mymanifest[gitdir][
                     'fingerprint']
             if len(lock_fails) >= pull_threads:
-                logger.info('Too many repositories locked (%s). Exiting.'
-                            % len(lock_fails))
+                logger.info('Too many repositories locked (%s). Exiting.',
+                            len(lock_fails))
                 return 0
             continue
 
@@ -655,7 +655,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
             logger.debug('Verifying %s', gitdir)
             if not os.path.exists(fullpath):
                 verify_fails.append(gitdir)
-                logger.info('Verify: %s ABSENT' % gitdir)
+                logger.info('Verify: %s ABSENT', gitdir)
                 grokmirror.unlock_repo(fullpath)
                 continue
 
@@ -663,7 +663,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
                 toplevel, gitdir, force=force)
 
             if my_fingerprint == culled[gitdir]['fingerprint']:
-                logger.info('Verify: %s OK' % gitdir)
+                logger.info('Verify: %s OK', gitdir)
             else:
                 logger.critical('Verify: %s FAILED' % gitdir)
                 verify_fails.append(gitdir)
@@ -715,7 +715,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
                     grokmirror.unlock_repo(fullpath)
                     continue
 
-                logger.info('Setting new origin for %s' % gitdir)
+                logger.info('Setting new origin for %s', gitdir)
                 fix_remotes(gitdir, toplevel, config['site'])
                 to_pull.append(gitdir)
                 grokmirror.unlock_repo(fullpath)
@@ -798,10 +798,9 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
             logger.info('Too many repositories locked. Exiting.')
             return 0
 
-        logger.info('Will use %d threads to pull repos' % pull_threads)
+        logger.info('Will use %d threads to pull repos', pull_threads)
 
-        logger.info('Updating %s repos from %s'
-                    % (len(to_pull), config['site']))
+        logger.info('Updating %s repos from %s', len(to_pull), config['site'])
         in_queue = Queue()
         out_queue = Queue()
 
@@ -840,8 +839,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
         to_clone = []
 
     if len(to_clone):
-        logger.info('Cloning %s repos from %s'
-                    % (len(to_clone), config['site']))
+        logger.info('Cloning %s repos from %s', len(to_clone), config['site'])
         # we use "existing" to track which repos can be used as references
         existing.extend(to_pull)
 
@@ -862,7 +860,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
             try:
                 grokmirror.lock_repo(fullpath, nonblocking=True)
             except IOError:
-                logger.info('Could not lock %s, skipping' % gitdir)
+                logger.info('Could not lock %s, skipping', gitdir)
                 lock_fails.append(gitdir)
                 continue
 
@@ -879,8 +877,8 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
                                          reference=reference)
                     grokmirror.unlock_repo(refrepo)
                 except IOError:
-                    logger.info('Cannot lock reference repo %s, skipping %s' %
-                                (reference, gitdir))
+                    logger.info('Cannot lock reference repo %s, skipping %s',
+                                reference, gitdir)
                     if reference not in lock_fails:
                         lock_fails.append(reference)
 
@@ -942,7 +940,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
 
                     # Here we re-check if we still need to do anything
                     if not os.path.exists(target):
-                        logger.info('Symlinking %s -> %s' % (target, source))
+                        logger.info('Symlinking %s -> %s', target, source)
                         # Make sure the leading dirs are in place
                         if not os.path.exists(os.path.dirname(target)):
                             os.makedirs(os.path.dirname(target))
@@ -996,22 +994,24 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
             else:
                 for founddir in to_purge:
                     if os.path.islink(founddir):
-                        logger.info('Removing unreferenced symlink %s' % gitdir)
+                        logger.info('Removing unreferenced symlink %s', gitdir)
                         os.unlink(founddir)
                     else:
                         # is anything using us for alternates?
                         gitdir = '/' + os.path.relpath(founddir, toplevel).lstrip('/')
                         repolist = grokmirror.find_all_alt_repos(gitdir, culled)
                         if repolist:
-                            logger.info('Not purging %s because it is used by other repos via alternates' % founddir)
+                            logger.info('Not purging %s because it is used by '
+                                        'other repos via alternates', founddir)
                         else:
                             try:
-                                logger.info('Purging %s' % founddir)
+                                logger.info('Purging %s', founddir)
                                 grokmirror.lock_repo(founddir, nonblocking=True)
                                 shutil.rmtree(founddir)
                             except IOError:
                                 lock_fails.append(gitdir)
-                                logger.info('%s is locked, not purging' % gitdir)
+                                logger.info('%s is locked, not purging',
+                                            gitdir)
 
     # Go through all repos in culled and get the latest local timestamps.
     for gitdir in culled:
@@ -1021,12 +1021,11 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
     # If there were any lock failures, we fudge last_modified to always
     # be older than the server, which will force the next grokmirror run.
     if len(lock_fails):
-        logger.info('%s repos could not be locked. Forcing next run.'
-                    % len(lock_fails))
+        logger.info('%s repos could not be locked. Forcing next run.',
+                    len(lock_fails))
         last_modified -= 1
     elif len(git_fails):
-        logger.info('%s repos failed. Forcing next run.'
-                    % len(git_fails))
+        logger.info('%s repos failed. Forcing next run.', len(git_fails))
         last_modified -= 1
 
     # Once we're done, save culled as our new manifest

--- a/grokmirror/pull.py
+++ b/grokmirror/pull.py
@@ -490,8 +490,8 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
     if config['manifest'].find('file:///') == 0:
         manifile = config['manifest'].replace('file://', '')
         if not os.path.exists(manifile):
-            logger.critical('Remote manifest not found in %s! Quitting!'
-                            % config['manifest'])
+            logger.critical('Remote manifest not found in %s! Quitting!',
+                            config['manifest'])
             return 1
 
         fstat = os.stat(manifile)
@@ -599,8 +599,8 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
 
     toplevel = config['toplevel']
     if not os.access(toplevel, os.W_OK):
-        logger.critical('Toplevel %s does not exist or is not writable'
-                        % toplevel)
+        logger.critical('Toplevel %s does not exist or is not writable',
+                        toplevel)
         sys.exit(1)
 
     if 'pull_threads' in config.keys():
@@ -664,7 +664,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
             if my_fingerprint == culled[gitdir]['fingerprint']:
                 logger.info('Verify: %s OK', gitdir)
             else:
-                logger.critical('Verify: %s FAILED' % gitdir)
+                logger.critical('Verify: %s FAILED', gitdir)
                 verify_fails.append(gitdir)
 
             grokmirror.unlock_repo(fullpath)
@@ -708,9 +708,9 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
             else:
                 # It exists on disk, but not in my manifest?
                 if noreuse:
-                    logger.critical('Found existing git repo in %s' % fullpath)
+                    logger.critical('Found existing git repo in %s', fullpath)
                     logger.critical('But you asked NOT to reuse repos')
-                    logger.critical('Skipping %s' % gitdir)
+                    logger.critical('Skipping %s', gitdir)
                     grokmirror.unlock_repo(fullpath)
                     continue
 
@@ -768,12 +768,12 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
 
         # If we got here, something is odd.
         # noinspection PyUnreachableCode
-        logger.critical('Could not figure out what to do with %s' % gitdir)
+        logger.critical('Could not figure out what to do with %s', gitdir)
         grokmirror.unlock_repo(fullpath)
 
     if verify:
         if len(verify_fails):
-            logger.critical('%s repos failed to verify' % len(verify_fails))
+            logger.critical('%s repos failed to verify', len(verify_fails))
             return 1
         else:
             logger.info('Verification successful')
@@ -905,7 +905,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
                 culled[gitdir]['fingerprint'] = my_fingerprint
                 run_post_update_hook(hookscript, toplevel, gitdir)
             else:
-                logger.critical('Was not able to clone %s' % gitdir)
+                logger.critical('Was not able to clone %s', gitdir)
                 # Remove it from our manifest so we can try re-cloning
                 # next time grok-pull runs
                 del culled[gitdir]
@@ -973,8 +973,8 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
                 purge_limit = int(config['purgeprotect'])
                 assert 1 <= purge_limit <= 99
             except (ValueError, AssertionError):
-                logger.critical('Warning: "%s" is not valid for purgeprotect.'
-                                % config['purgeprotect'])
+                logger.critical('Warning: "%s" is not valid for purgeprotect.',
+                                config['purgeprotect'])
                 logger.critical('Please set to a number between 1 and 99.')
                 logger.critical('Defaulting to purgeprotect=5.')
                 purge_limit = 5
@@ -984,8 +984,8 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
             logger.debug('purge prercentage=%s', purge_pc)
 
             if not forcepurge and purge_pc >= purge_limit:
-                logger.critical('Refusing to purge %s repos (%s%%)'
-                                % (len(to_purge), purge_pc))
+                logger.critical('Refusing to purge %s repos (%s%%)',
+                                len(to_purge), purge_pc)
                 logger.critical('Set purgeprotect to a higher percentage, or'
                                 ' override with --force-purge.')
                 logger.info('Not saving local manifest')

--- a/grokmirror/pull.py
+++ b/grokmirror/pull.py
@@ -76,8 +76,8 @@ class PullerThread(threading.Thread):
             # already done this for us?
             todo = True
             success = False
-            logger.debug('[Thread-%s] gitdir=%s, figerprint=%s, modified=%s'
-                         % (self.myname, gitdir, fingerprint, modified))
+            logger.debug('[Thread-%s] gitdir=%s, figerprint=%s, modified=%s',
+                         self.myname, gitdir, fingerprint, modified)
 
             fullpath = os.path.join(self.toplevel, gitdir.lstrip('/'))
 
@@ -91,14 +91,14 @@ class PullerThread(threading.Thread):
                 if fingerprint is None:
                     ts = grokmirror.get_repo_timestamp(self.toplevel, gitdir)
                     if ts >= modified:
-                        logger.debug('[Thread-%s] TS same or newer, not pulling %s'
-                                     % (self.myname, gitdir))
+                        logger.debug('[Thread-%s] TS same or newer, '
+                                     'not pulling %s', self.myname, gitdir)
                         todo = False
                 else:
                     # Recheck the real fingerprint to make sure there is no
                     # divergence between grokmirror.fingerprint and real repo
-                    logger.debug('[Thread-%s] Rechecking fingerprint in %s' %
-                                 (self.myname, gitdir))
+                    logger.debug('[Thread-%s] Rechecking fingerprint in %s',
+                                 self.myname, gitdir)
                     my_fingerprint = grokmirror.get_repo_fingerprint(
                         self.toplevel, gitdir, force=True)
 
@@ -107,13 +107,13 @@ class PullerThread(threading.Thread):
                         self.toplevel, gitdir, fingerprint=my_fingerprint)
 
                     if fingerprint == my_fingerprint:
-                        logger.debug('[Thread-%s] FP match, not pulling %s'
-                                     % (self.myname, gitdir))
+                        logger.debug('[Thread-%s] FP match, not pulling %s',
+                                     self.myname, gitdir)
                         todo = False
 
                 if not todo:
-                    logger.debug('[Thread-%s] %s already latest, skipping'
-                                 % (self.myname, gitdir))
+                    logger.debug('[Thread-%s] %s already latest, skipping',
+                                 self.myname, gitdir)
                     set_agefile(self.toplevel, gitdir, modified)
                     grokmirror.unlock_repo(fullpath)
                     self.out_queue.put((gitdir, my_fingerprint, True))
@@ -122,8 +122,8 @@ class PullerThread(threading.Thread):
 
                 logger.info('[Thread-%s] updating %s' % (self.myname, gitdir))
                 success = pull_repo(self.toplevel, gitdir, threadid=self.myname)
-                logger.debug('[Thread-%s] done pulling %s' %
-                             (self.myname, gitdir))
+                logger.debug('[Thread-%s] done pulling %s',
+                             self.myname, gitdir)
 
                 if success:
                     set_agefile(self.toplevel, gitdir, modified)
@@ -178,15 +178,15 @@ def fix_remotes(gitdir, toplevel, site):
     repo = Repo(os.path.join(toplevel, gitdir.lstrip('/')))
     remotes = repo.git.remote()
     if len(remotes.strip()):
-        logger.debug('existing remotes: %s' % remotes)
+        logger.debug('existing remotes: %s', remotes)
         for name in remotes.split('\n'):
-            logger.debug('\tremoving remote: %s' % name)
+            logger.debug('\tremoving remote: %s', name)
             repo.git.remote('rm', name)
 
     # set my origin
     origin = os.path.join(site, gitdir.lstrip('/'))
     repo.git.remote('add', '--mirror', 'origin', origin)
-    logger.debug('\tset new origin as %s' % origin)
+    logger.debug('\tset new origin as %s', origin)
 
 
 def set_repo_params(toplevel, gitdir, owner, description, reference):
@@ -200,18 +200,18 @@ def set_repo_params(toplevel, gitdir, owner, description, reference):
     if description is not None:
         try:
             if repo.description != description:
-                logger.debug('Setting %s description to: %s' %
-                             (gitdir, description))
+                logger.debug('Setting %s description to: %s',
+                             gitdir, description)
                 repo.description = description
         except IOError:
             # Bug in git-python will throw an exception if description
             # file is not found
-            logger.debug('%s description file missing, setting to: %s' %
-                         (gitdir, description))
+            logger.debug('%s description file missing, setting to: %s',
+                         gitdir, description)
             repo.description = description
 
     if owner is not None:
-        logger.debug('Setting %s owner to: %s' % (gitdir, owner))
+        logger.debug('Setting %s owner to: %s', gitdir, owner)
         repo.git.config('gitweb.owner', owner)
 
     if reference is not None:
@@ -242,7 +242,7 @@ def set_agefile(toplevel, gitdir, last_modified):
         os.makedirs(os.path.dirname(agefile))
     with open(agefile, 'wt') as fh:
         fh.write('%s\n' % cgit_fmt)
-    logger.debug('Wrote "%s" into %s' % (cgit_fmt, agefile))
+    logger.debug('Wrote "%s" into %s', cgit_fmt, agefile)
 
 
 def run_post_update_hook(hookscript, toplevel, gitdir, threadid='X'):
@@ -255,7 +255,7 @@ def run_post_update_hook(hookscript, toplevel, gitdir, threadid='X'):
 
     fullpath = os.path.join(toplevel, gitdir.lstrip('/'))
     args = [hookscript, fullpath]
-    logger.debug('[Thread-%s] Running: %s' % (threadid, ' '.join(args)))
+    logger.debug('[Thread-%s] Running: %s', threadid, ' '.join(args))
     (output, error) = subprocess.Popen(args, stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE,
                                        universal_newlines=True).communicate()
@@ -274,8 +274,8 @@ def pull_repo(toplevel, gitdir, threadid='X'):
     env = {'GIT_DIR': os.path.join(toplevel, gitdir.lstrip('/'))}
     args = ['/usr/bin/git', 'remote', 'update', '--prune']
 
-    logger.debug('[Thread-%s] Running: GIT_DIR=%s %s'
-                 % (threadid, env['GIT_DIR'], ' '.join(args)))
+    logger.debug('[Thread-%s] Running: GIT_DIR=%s %s',
+                 threadid, env['GIT_DIR'], ' '.join(args))
 
     child = subprocess.Popen(args, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE, env=env,
@@ -300,8 +300,7 @@ def pull_repo(toplevel, gitdir, threadid='X'):
             else:
                 warn.append(line)
         if debug:
-            logger.debug('[Thread-%s] Stderr: %s'
-                         % (threadid, '\n'.join(debug)))
+            logger.debug('[Thread-%s] Stderr: %s', threadid, '\n'.join(debug))
         if warn:
             logger.warning('[Thread-%s] Stderr: %s'
                            % (threadid, '\n'.join(warn)))
@@ -326,7 +325,7 @@ def clone_repo(toplevel, gitdir, site, reference=None):
     if reference is not None:
         logger.info('With reference to %s' % reference)
 
-    logger.debug('Running: %s' % ' '.join(args))
+    logger.debug('Running: %s', ' '.join(args))
 
     child = subprocess.Popen(args, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
@@ -350,7 +349,7 @@ def clone_repo(toplevel, gitdir, site, reference=None):
             else:
                 warn.append(line)
         if debug:
-            logger.debug('Stderr: %s' % '\n'.join(debug))
+            logger.debug('Stderr: %s', '\n'.join(debug))
         if warn:
             logger.warning('Stderr: %s' % '\n'.join(warn))
 
@@ -364,20 +363,20 @@ def clone_order(to_clone, manifest, to_clone_sorted, existing):
     logger.debug('Another clone_order loop')
     for gitdir in to_clone:
         reference = manifest[gitdir]['reference']
-        logger.debug('reference: %s' % reference)
+        logger.debug('reference: %s', reference)
         if (reference in existing
             or reference in to_clone_sorted
                 or reference is None):
-            logger.debug('%s: reference found in existing' % gitdir)
+            logger.debug('%s: reference found in existing', gitdir)
             to_clone_sorted.append(gitdir)
         else:
-            logger.debug('%s: reference not found' % gitdir)
+            logger.debug('%s: reference not found', gitdir)
             new_to_clone.append(gitdir)
     if len(new_to_clone) == 0 or len(new_to_clone) == num_received:
         # we can resolve no more dependencies, break out
         logger.debug('Finished resolving dependencies, quitting')
         if len(new_to_clone):
-            logger.debug('Unresolved: %s' % new_to_clone)
+            logger.debug('Unresolved: %s', new_to_clone)
             to_clone_sorted.extend(new_to_clone)
         return
 
@@ -498,12 +497,12 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
 
         fstat = os.stat(manifile)
         last_modified = fstat[8]
-        logger.debug('mtime on %s is: %s' % (manifile, fstat[8]))
+        logger.debug('mtime on %s is: %s', manifile, fstat[8])
 
         if os.path.exists(config['mymanifest']):
             fstat = os.stat(config['mymanifest'])
             my_last_modified = fstat[8]
-            logger.debug('Our last-modified is: %s' % my_last_modified)
+            logger.debug('Our last-modified is: %s', my_last_modified)
             if not (force or nomtime) and last_modified <= my_last_modified:
                 logger.info('Manifest file unchanged. Quitting.')
                 return 0
@@ -531,7 +530,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
                 password = ''
 
             manifesturl = config['manifest'].replace(chunks.netloc, netloc)
-            logger.debug('manifesturl=%s' % manifesturl)
+            logger.debug('manifesturl=%s', manifesturl)
             request = urllib_request.Request(manifesturl)
 
             password_mgr = urllib_request.HTTPPasswordMgrWithDefaultRealm()
@@ -547,10 +546,10 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
         if not (force or nomtime) and os.path.exists(mymanifest):
             fstat = os.stat(mymanifest)
             mtime = fstat[8]
-            logger.debug('mtime on %s is: %s' % (mymanifest, mtime))
+            logger.debug('mtime on %s is: %s', mymanifest, mtime)
             my_last_modified = time.strftime('%a, %d %b %Y %H:%M:%S GMT',
                                              time.gmtime(mtime))
-            logger.debug('Our last-modified is: %s' % my_last_modified)
+            logger.debug('Our last-modified is: %s', my_last_modified)
             request.add_header('If-Modified-Since', my_last_modified)
 
         try:
@@ -645,7 +644,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
 
         if verify:
             if culled[gitdir]['fingerprint'] is None:
-                logger.debug('No fingerprint for %s, not verifying' % gitdir)
+                logger.debug('No fingerprint for %s, not verifying', gitdir)
                 grokmirror.unlock_repo(fullpath)
                 continue
 
@@ -653,7 +652,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
                 grokmirror.unlock_repo(fullpath)
                 continue
 
-            logger.debug('Verifying %s' % gitdir)
+            logger.debug('Verifying %s', gitdir)
             if not os.path.exists(fullpath):
                 verify_fails.append(gitdir)
                 logger.info('Verify: %s ABSENT' % gitdir)
@@ -726,20 +725,20 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
             # in the remote manifest, fall back on using timestamps
             changed = False
             if culled[gitdir]['fingerprint'] is not None:
-                logger.debug('Will use fingerprints to compare %s' % gitdir)
+                logger.debug('Will use fingerprints to compare %s', gitdir)
                 my_fingerprint = grokmirror.get_repo_fingerprint(toplevel,
                                                                  gitdir,
                                                                  force=force)
 
                 if my_fingerprint != culled[gitdir]['fingerprint']:
-                    logger.debug('No fingerprint match, will pull %s' % gitdir)
+                    logger.debug('No fingerprint match, will pull %s', gitdir)
                     changed = True
                 else:
-                    logger.debug('Fingerprints match, skipping %s' % gitdir)
+                    logger.debug('Fingerprints match, skipping %s', gitdir)
             else:
-                logger.debug('Will use timestamps to compare %s' % gitdir)
+                logger.debug('Will use timestamps to compare %s', gitdir)
                 if force:
-                    logger.debug('Will force-pull %s' % gitdir)
+                    logger.debug('Will force-pull %s', gitdir)
                     changed = True
                     # set timestamp to 0 as well
                     grokmirror.set_repo_timestamp(toplevel, gitdir, 0)
@@ -753,7 +752,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
                 grokmirror.unlock_repo(fullpath)
                 continue
             else:
-                logger.debug('Repo %s unchanged' % gitdir)
+                logger.debug('Repo %s unchanged', gitdir)
                 # if we don't have a fingerprint for it, add it now
                 if culled[gitdir]['fingerprint'] is None:
                     fpr = grokmirror.get_repo_fingerprint(toplevel, gitdir)
@@ -811,7 +810,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
                           culled[gitdir]['modified']))
 
         for i in range(pull_threads):
-            logger.debug('Spun up thread %s' % i)
+            logger.debug('Spun up thread %s', i)
             t = PullerThread(in_queue, out_queue, config, i)
             t.setDaemon(True)
             t.start()
@@ -828,7 +827,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
             if not status:
                 # To make sure we check this again during next run,
                 # fudge the manifest accordingly.
-                logger.debug('Will recheck %s during next run' % gitdir)
+                logger.debug('Will recheck %s during next run', gitdir)
                 culled[gitdir] = mymanifest[gitdir]
                 # this is rather hackish, but effective
                 last_modified -= 1
@@ -855,7 +854,7 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
             ts = grokmirror.get_repo_timestamp(toplevel, gitdir)
 
             if ts > 0:
-                logger.debug('Looks like %s already cloned, skipping' % gitdir)
+                logger.debug('Looks like %s already cloned, skipping', gitdir)
                 continue
 
             fullpath = os.path.join(toplevel, gitdir.lstrip('/'))
@@ -892,8 +891,8 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
 
             # check dir to make sure cloning succeeded and then add to existing
             if os.path.exists(fullpath) and success:
-                logger.debug('Cloning of %s succeeded, adding to existing'
-                             % gitdir)
+                logger.debug('Cloning of %s succeeded, adding to existing',
+                             gitdir)
                 existing.append(gitdir)
 
                 desc = culled[gitdir].get('description')
@@ -933,8 +932,8 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
                         # are you pointing to where we need you?
                         if os.path.realpath(target) != source:
                             # Remove symlink and recreate below
-                            logger.debug('Removed existing wrong symlink %s'
-                                         % target)
+                            logger.debug('Removed existing wrong symlink %s',
+                                         target)
                             os.unlink(target)
                     elif os.path.exists(target):
                         logger.warn('Deleted repo %s, because it is now'
@@ -984,8 +983,8 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
                 purge_limit = 5
 
             purge_pc = len(to_purge) * 100 / found_repos
-            logger.debug('purgeprotect=%s' % purge_limit)
-            logger.debug('purge prercentage=%s' % purge_pc)
+            logger.debug('purgeprotect=%s', purge_limit)
+            logger.debug('purge prercentage=%s', purge_pc)
 
             if not forcepurge and purge_pc >= purge_limit:
                 logger.critical('Refusing to purge %s repos (%s%%)'

--- a/grokmirror/pull.py
+++ b/grokmirror/pull.py
@@ -130,8 +130,8 @@ class PullerThread(threading.Thread):
                     run_post_update_hook(self.hookscript, self.toplevel, gitdir,
                                          threadid=self.myname)
                 else:
-                    logger.warning('[Thread-%s] pulling %s unsuccessful'
-                                   % (self.myname, gitdir))
+                    logger.warning('[Thread-%s] pulling %s unsuccessful',
+                                   self.myname, gitdir)
                     git_fails.append(gitdir)
 
                 # Record our current fingerprint and return it
@@ -249,8 +249,8 @@ def run_post_update_hook(hookscript, toplevel, gitdir, threadid='X'):
     if hookscript == '':
         return
     if not os.access(hookscript, os.X_OK):
-        logger.warning('[Thread-%s] post_update_hook %s is not executable'
-                       % (threadid, hookscript))
+        logger.warning('[Thread-%s] post_update_hook %s is not executable',
+                       threadid, hookscript)
         return
 
     fullpath = os.path.join(toplevel, gitdir.lstrip('/'))
@@ -264,7 +264,7 @@ def run_post_update_hook(hookscript, toplevel, gitdir, threadid='X'):
     output = output.strip()
     if error:
         # Put hook stderror into warning
-        logger.warning('[Thread-%s] Hook Stderr: %s' % (threadid, error))
+        logger.warning('[Thread-%s] Hook Stderr: %s', threadid, error)
     if output:
         # Put hook stdout into info
         logger.info('[Thread-%s] Hook Stdout: %s', threadid, output)
@@ -302,8 +302,7 @@ def pull_repo(toplevel, gitdir, threadid='X'):
         if debug:
             logger.debug('[Thread-%s] Stderr: %s', threadid, '\n'.join(debug))
         if warn:
-            logger.warning('[Thread-%s] Stderr: %s'
-                           % (threadid, '\n'.join(warn)))
+            logger.warning('[Thread-%s] Stderr: %s', threadid, '\n'.join(warn))
 
     return success
 
@@ -351,7 +350,7 @@ def clone_repo(toplevel, gitdir, site, reference=None):
         if debug:
             logger.debug('Stderr: %s', '\n'.join(debug))
         if warn:
-            logger.warning('Stderr: %s' % '\n'.join(warn))
+            logger.warning('Stderr: %s', '\n'.join(warn))
 
     return success
 
@@ -559,12 +558,12 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
                 logger.info('Server says we have the latest manifest. '
                             'Quitting.')
                 return 0
-            logger.warning('Could not fetch %s' % config['manifest'])
-            logger.warning('Server returned: %s' % ex)
+            logger.warning('Could not fetch %s', config['manifest'])
+            logger.warning('Server returned: %s', ex)
             return 1
         except URLError as ex:
-            logger.warning('Could not fetch %s' % config['manifest'])
-            logger.warning('Error was: %s' % ex)
+            logger.warning('Could not fetch %s', config['manifest'])
+            logger.warning('Error was: %s', ex)
             return 1
 
         last_modified = ufh.headers.get('Last-Modified')
@@ -586,8 +585,8 @@ def pull_mirror(name, config, verbose=False, force=False, nomtime=False,
             manifest = anyjson.deserialize(jdata)
 
         except Exception as ex:
-            logger.warning('Failed to parse %s' % config['manifest'])
-            logger.warning('Error was: %s' % ex)
+            logger.warning('Failed to parse %s', config['manifest'])
+            logger.warning('Error was: %s', ex)
             return 1
 
     mymanifest = grokmirror.read_manifest(mymanifest)


### PR DESCRIPTION
Logging methods are not supposed to be pre-interpolated. They accept all remaining arguments and do the interpolation themselves.