### PR TITLE
pi-indexer: fix pi-indexer init [inboxdir] call

### DIFF
--- a/grokmirror/pi_indexer.py
+++ b/grokmirror/pi_indexer.py
@@ -250,7 +250,7 @@ def get_git_pi_dir(opts, fullpath: str) -> Tuple[str, str]:
 
 def cmd_init(opts):
     if opts.inboxdir:
-        inboxdirs = get_inboxdirs(opts.inboxdir)
+        inboxdirs = get_inboxdirs([opts.inboxdir])
         if opts.forceinit:
             inboxdir = inboxdirs.pop()
             gdir, pdir = get_git_pi_dir(opts, inboxdir)


### PR DESCRIPTION
In init mode opts.inboxdir is a string. get_inboxdirs() accepts
a list. Thus the string is interpreted as a list of chars resulting
in get_inboxdirs() returns an empty set. This means a call:
```
	$ grok-pi-indexer -v init /.../lkml/git/0.git
```
will always return:
```
	> Nothing to do.
```

Fix it by casting a string to a single element list.

Signed-off-by: Denis Efremov <denis.e.efremov@oracle.com>