### PR TITLE
pi-indexer: fix init --force-init call

### DIFF
--- a/grokmirror/pi_indexer.py
+++ b/grokmirror/pi_indexer.py
@@ -252,7 +252,7 @@ def cmd_init(opts):
     if opts.inboxdir:
         inboxdirs = get_inboxdirs(opts.inboxdir)
         if opts.forceinit:
-            inboxdir = inboxdirs.pop()
+            inboxdir = list(inboxdirs)[0] # get first element from the set
             gdir, pdir = get_git_pi_dir(opts, inboxdir)
             msgmapdbf = os.path.join(pdir, 'msgmap.sqlite3')
             # Delete msgmap and xap15 if present and reinitialize


### PR DESCRIPTION
Don't pop the only inboxdir from inboxdirs set. We need it later to
actually reinit the inboxdir.

Signed-off-by: Denis Efremov <denis.e.efremov@oracle.com>